### PR TITLE
fix entity request proxy crash

### DIFF
--- a/control/circuit-pole.lua
+++ b/control/circuit-pole.lua
@@ -1,7 +1,7 @@
 local math2d = require("math2d")
 require "libs.lua.string"
 
--- Registering entity into system
+-- Registering entity into system 
 local circuitPole = {}
 entities["circuit-pole"] = circuitPole
 

--- a/control/compact-combinator.lua
+++ b/control/compact-combinator.lua
@@ -134,6 +134,7 @@ entityMethods.build = function(entity, player)
 	Surface.placeTiles(data.chunkPos, data.size)
 	local surface = Surface.get()
 	local chunkMiddle = Surface.chunkMiddle(data.chunkPos)
+	surface.set_chunk_generated_status(data.chunkPos, defines.chunk_generated_status.entities)
 	for y=-3,3,2 do for x=-3,3,2 do
 		if math.abs(x)==3 or math.abs(y)==3 then
 			local p = entity.surface.find_entity("compact-combinator-io",{x=position.x+x*0.25 , y=position.y+y*0.25})
@@ -364,6 +365,7 @@ private.pasteStructuresIfBlueprinted = function(data, entity)
 	if id == nil or id == 0 or cir.get_signal(5).signal == nil then return end
 	local surface = Surface.get()
 	local chunkMiddle = Surface.chunkMiddle(data.chunkPos)
+	surface.set_chunk_generated_status(data.chunkPos, defines.chunk_generated_status.entities)
 	local blueprint = Surface.templateInventory()[id]
 	if not blueprint.valid or not blueprint.valid_for_read then return end
 	local direction = (entity.direction - directionOld + 8) % 8
@@ -383,9 +385,15 @@ private.pasteStructuresIfBlueprinted = function(data, entity)
 	data.chest.operable=true
 	data.chest.destructible = false
 	data.chest.minable = false
+	
+	if next(request) ~= nil then
+
 	data.proxy = entity.surface.create_entity{
 		name="item-request-proxy",position=data.chest.position,target=data.chest,modules=request,force=entity.force
 	}
+
+end
+		
 	private.updateBlueprintOf(entity, data)
 end
 

--- a/prototypes/circuit-pole.lua
+++ b/prototypes/circuit-pole.lua
@@ -44,7 +44,7 @@ overwriteContent(circuitPole, {
 	},
 	maximum_wire_distance = 15,
 	supply_area_distance = 0,
-	draw_copper_wires = false,
+	draw_copper_wires = true,
 	pictures = {
 		filename = "__integratedCircuitryFixed__/graphics/entity/circuit-pole.png",
 		priority = "extra-high",


### PR DESCRIPTION
Factorio 1.1 will not paste blueprints to an unexplored chunk. When trying to copy and paste a compact combinator, the call to create an entity request proxy is passed a null list of blueprint entities. by setting the chunk as "generated", this allows the blueprint to be pasted, fixing the crash.